### PR TITLE
Optimize generate_pi_combinations

### DIFF
--- a/Assignment_1_Solution/Gemfile
+++ b/Assignment_1_Solution/Gemfile
@@ -1,2 +1,3 @@
 source 'http://rubygems.org'
 gem 'pry'
+gem 'colorize'

--- a/Assignment_1_Solution/Gemfile.lock
+++ b/Assignment_1_Solution/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     coderay (1.1.0)
+    colorize (0.7.5)
     method_source (0.8.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -20,4 +21,5 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  colorize
   pry

--- a/Assignment_1_Solution/algo.rb
+++ b/Assignment_1_Solution/algo.rb
@@ -77,13 +77,15 @@ class Algo
   end
 
   def generate_pi_combinations(ess_pi_list, non_ess_pi_list)
-    pi_list = ess_pi_list + non_ess_pi_list
+    # pi_list = ess_pi_list + non_ess_pi_list
+    # we will calculate all possible combinations on non-essential PIs and will add ess. PIs to them
+    pi_list = non_ess_pi_list
+    puts "pi_list length: #{pi_list.length}"
     pi_combinations = []
     (1..pi_list.length).each do |i|
       # puts "i: #{i}"
       # puts pi_list.combination(i).to_a.inspect
-      pi_list.combination(i).to_a.each {|a| pi_combinations << a}
-      # pi_combinations.push(pi_list.combination(i).to_a)
+      pi_list.combination(i).to_a.each { |a| pi_combinations << a + ess_pi_list }
     end
     
     pi_combinations.push(ess_pi_list)
@@ -208,7 +210,7 @@ class Algo
       cover_value_hash[cover_cost] << cover
     end
     puts
-    puts "cover_value_hash: #{cover_value_hash.inspect}"
+    # puts "cover_value_hash: #{cover_value_hash.inspect}"
     minimum_cost_cover =  cover_value_hash.sort_by {|key, value| key}
     puts "minimum_cost_cover: #{minimum_cost_cover[0][1]}"
     puts "minimum_cost_cover length: #{minimum_cost_cover[0][1].length}"

--- a/Assignment_1_Solution/algo.rb
+++ b/Assignment_1_Solution/algo.rb
@@ -16,13 +16,13 @@ class Algo
     @cover_list = []
   end
 
-  def calculate_essential_pi_list(current_pi_list)
+  def calculate_essential_pi_list(current_pi_list, dc_set)
     categorized_pi_list = []
     working_pi_list = []
     (0...current_pi_list.length).each do |i|
 
-      working_pi_list = current_pi_list.clone
-      working_pi_list.delete_at(i)
+      working_pi_list = current_pi_list.clone + dc_set.clone
+      working_pi_list.delete_at(i)  #removing the current PI since it shouldn't be sharped with itself
 
       if is_PI_Essential( current_pi_list[i], working_pi_list)
         @essential_pi_list.push( current_pi_list[i])

--- a/Assignment_1_Solution/algo.rb
+++ b/Assignment_1_Solution/algo.rb
@@ -165,7 +165,6 @@ class Algo
     else
       if does_pi_list_fully_cover_function(minterms, current_cover)
       @cover_list.push(current_cover)
-      # @cover_list = remove_duplicates(@cover_list)
       return
       else
         original_working_set = working_set.clone
@@ -200,7 +199,8 @@ class Algo
   def find_minimum_cost_cover(cover_list, file_name)
     starter_kit = StarterKit.new(file_name)
     puts "\nFinding Minimum Cost Cover . . . "
-    new_covers = remove_duplicates(cover_list)
+    new_covers = cover_list # with the combination approach, we won't get duplicate covers
+    #new_covers = remove_duplicates(cover_list)
     # Finding covers costs and minimum cost cover
     cover_value_hash = Hash.new{|h, k| h[k] = []}
     new_covers.each do |cover|

--- a/Assignment_1_Solution/algo.rb
+++ b/Assignment_1_Solution/algo.rb
@@ -72,7 +72,7 @@ class Algo
     # pi_list = ess_pi_list + non_ess_pi_list
     # we will calculate all possible combinations on non-essential PIs and will add ess. PIs to them
     pi_list = non_ess_pi_list
-    puts "pi_list length: #{pi_list.length}"
+    puts "Number of non-essential PIs: #{pi_list.length}"
     pi_combinations = []
     
     pi_combinations.push(ess_pi_list)  # only the essential PIs list a possible combination    
@@ -88,7 +88,7 @@ class Algo
       # ess_pi_list.combination(i).to_a.each { |a| pi_combinations << a }
     # end
    
-    puts "pi_combinations size: #{pi_combinations.length}"
+    puts "Number of potential covers: #{pi_combinations.length}"
     pi_combinations
   end
 
@@ -211,7 +211,7 @@ class Algo
     puts
     # puts "cover_value_hash: #{cover_value_hash.inspect}"
     minimum_cost_cover =  cover_value_hash.sort_by {|key, value| key}
-    puts "minimum_cost_cover length: #{minimum_cost_cover[0][1].length}"
+    puts "Number of minimum cost covers: #{minimum_cost_cover[0][1].length}"
     puts "minimum_cost_cover: #{minimum_cost_cover[0][1]}".colorize(:light_blue)
     puts "cost of minimum_cost_cover: #{minimum_cost_cover[0][0]}".blue.blink
     puts

--- a/Assignment_1_Solution/algo.rb
+++ b/Assignment_1_Solution/algo.rb
@@ -87,8 +87,12 @@ class Algo
       # puts pi_list.combination(i).to_a.inspect
       pi_list.combination(i).to_a.each { |a| pi_combinations << a + ess_pi_list }
     end
+
+    (1..ess_pi_list.length).each do |i|
+      ess_pi_list.combination(i).to_a.each { |a| pi_combinations << a }
+    end
     
-    pi_combinations.push(ess_pi_list)
+    # pi_combinations.push(ess_pi_list)
     puts "pi_combinations size: #{pi_combinations.length}"
     pi_combinations
   end

--- a/Assignment_1_Solution/algo.rb
+++ b/Assignment_1_Solution/algo.rb
@@ -4,7 +4,6 @@ require 'colorize'
 
 class Algo
   attr_accessor :essential_pi_list, :non_essential_pi_list, :cover_list
-
   def initialize
     @pi_list = []
     @essential_pi_list = []
@@ -25,9 +24,9 @@ class Algo
       working_pi_list.delete_at(i)  #removing the current PI since it shouldn't be sharped with itself
 
       if is_PI_Essential( current_pi_list[i], working_pi_list)
-        @essential_pi_list.push( current_pi_list[i])
+      @essential_pi_list.push( current_pi_list[i])
       else
-        @non_essential_pi_list.push( current_pi_list[i])
+      @non_essential_pi_list.push( current_pi_list[i])
       end
     end
 
@@ -35,7 +34,7 @@ class Algo
     categorized_pi_list.push(@non_essential_pi_list)
     categorized_pi_list
   end
-  
+
   def does_pi_list_fully_cover_function(minterms, current_cover)
     minterm_coverage_list = []
     minterm_coverage_list = get_minterm_function_coverage(minterms, current_cover)
@@ -46,27 +45,27 @@ class Algo
 
   # this function calculates if the provided cover completely covers all the minterms/implicants
   def get_minterm_function_coverage(minterms, current_cover)
-      minterms_fully_covered = []
-      minterms_not_fully_covered = []
+    minterms_fully_covered = []
+    minterms_not_fully_covered = []
 
-      minterm_coverage_list = []
+    minterm_coverage_list = []
 
-      working_pi_list = current_cover.clone
+    working_pi_list = current_cover.clone
 
-       (0...minterms.length).each do |i|
+    (0...minterms.length).each do |i|
 
-         if is_PI_Essential( minterms[i], working_pi_list)
-           minterms_not_fully_covered.push( minterms[i])
-         else
-           minterms_fully_covered.push( minterms[i])
-         end
-       end
+      if is_PI_Essential( minterms[i], working_pi_list)
+      minterms_not_fully_covered.push( minterms[i])
+      else
+      minterms_fully_covered.push( minterms[i])
+      end
+    end
 
-     minterm_coverage_list.push(minterms_fully_covered)
-     minterm_coverage_list.push(minterms_not_fully_covered)
+    minterm_coverage_list.push(minterms_fully_covered)
+    minterm_coverage_list.push(minterms_not_fully_covered)
 
-     return minterm_coverage_list
-      #return (minterms_not_fully_covered.length == 0)
+    return minterm_coverage_list
+  #return (minterms_not_fully_covered.length == 0)
   end
 
   def generate_pi_combinations(ess_pi_list, non_ess_pi_list)
@@ -75,21 +74,24 @@ class Algo
     pi_list = non_ess_pi_list
     puts "pi_list length: #{pi_list.length}"
     pi_combinations = []
+    
+    pi_combinations.push(ess_pi_list)  # only the essential PIs list a possible combination    
+    
+    # Adding non-essentials PIs with the essential PI list to generate other possible combination of covers
     (1..pi_list.length).each do |i|
-      # puts "i: #{i}"
-      # puts pi_list.combination(i).to_a.inspect
+    # puts "i: #{i}"
+    # puts pi_list.combination(i).to_a.inspect
       pi_list.combination(i).to_a.each { |a| pi_combinations << a + ess_pi_list }
     end
 
-    (1..ess_pi_list.length).each do |i|
-      ess_pi_list.combination(i).to_a.each { |a| pi_combinations << a }
-    end
-    
-    # pi_combinations.push(ess_pi_list)
+    # (1..ess_pi_list.length).each do |i|
+      # ess_pi_list.combination(i).to_a.each { |a| pi_combinations << a }
+    # end
+   
     puts "pi_combinations size: #{pi_combinations.length}"
     pi_combinations
   end
-    
+
   def is_PI_Essential(pi, working_pi_list)
     is_essential = false
     working_pi_list_index = 0
@@ -109,7 +111,7 @@ class Algo
     else
 
       if( result == 'NULL')
-        return false;
+      return false;
       else
         new_result = sharp.sharp_operation(result, working_pi_list[current_index])
         (0...new_result.length).each do |i|
@@ -117,7 +119,7 @@ class Algo
             is_essential = is_essential || chain_sharp(new_result[i], current_index + 1, working_pi_list)
           end
         end
-        return is_essential
+      return is_essential
       end
     end
   end
@@ -125,27 +127,27 @@ class Algo
   def find_all_covers(initial_cover, essential_pi_list, non_essential_pi_list)
     current_cover = essential_pi_list.clone
     working_set = non_essential_pi_list.clone
-	  @cover_list.clear
-	  
-	  check_coverage_combinations(initial_cover, essential_pi_list, non_essential_pi_list)
+    @cover_list.clear
+
+    check_coverage_combinations(initial_cover, essential_pi_list, non_essential_pi_list)
     #check_coverage_recursion(initial_cover, current_cover, working_set)
-    
-	  return @cover_list
+
+    return @cover_list
   end
-  
+
   def check_coverage_combinations(minterms, essential_pi_list, non_essential_pi_list)
     possible_covers = generate_pi_combinations(essential_pi_list, non_essential_pi_list)
-    
+
     #possible_covers.push(essential_pi_list)
-    
-     (0...possible_covers.length).each do |i|
-       #current_cover = essential_pi_list + possible_covers[i]
-       current_cover = possible_covers[i]
+
+    (0...possible_covers.length).each do |i|
+    #current_cover = essential_pi_list + possible_covers[i]
+      current_cover = possible_covers[i]
       if does_pi_list_fully_cover_function(minterms, current_cover)
-        @cover_list.push(possible_covers[i])
+      @cover_list.push(possible_covers[i])
       end
 
-     end
+    end
   end
 
   def check_coverage_recursion(minterms, current_cover, working_set)
@@ -153,32 +155,32 @@ class Algo
     #working_set = [p3, p4, p5]
     if (working_set.length == 0)
       # all the minterms have been added to cover
-      
+
       unless(@all_minterms_added_to_cover)
         @cover_list.push(current_cover)
         @all_minterms_added_to_cover = true
       end
-      
+
+    return
+    else
+      if does_pi_list_fully_cover_function(minterms, current_cover)
+      @cover_list.push(current_cover)
+      # @cover_list = remove_duplicates(@cover_list)
       return
-    else		
-      if does_pi_list_fully_cover_function(minterms, current_cover)        
-        @cover_list.push(current_cover)
-        # @cover_list = remove_duplicates(@cover_list)
-        return      
       else
         original_working_set = working_set.clone
         original_cover = current_cover.clone
-        
+
         (0...original_working_set.length).each do |j|
-          new_cover = original_cover.clone        
+          new_cover = original_cover.clone
           new_working_set = original_working_set.clone
-          
+
           new_cover.push(new_working_set.delete_at(j))
           # new_cover = [p1, p2, p3]
           # working set = [p4, p5]
           check_coverage_recursion(minterms, new_cover, new_working_set)
         end
-        return
+      return
       end
     end
   end

--- a/Assignment_1_Solution/algo.rb
+++ b/Assignment_1_Solution/algo.rb
@@ -1,8 +1,6 @@
 require './prime_implicant'
-require './sharp_operation'
-require './star_operation'
 require 'pry'
-require './starter_kit'
+require 'colorize'
 
 class Algo
   attr_accessor :essential_pi_list, :non_essential_pi_list, :cover_list
@@ -19,28 +17,23 @@ class Algo
   end
 
   def calculate_essential_pi_list(current_pi_list)
-      # debug info; should be removed from final version
-      puts 'calculating essential PIs:'
+    categorized_pi_list = []
+    working_pi_list = []
+    (0...current_pi_list.length).each do |i|
 
-     categorized_pi_list = []
-     working_pi_list = []
+      working_pi_list = current_pi_list.clone
+      working_pi_list.delete_at(i)
 
-      (0...current_pi_list.length).each do |i|
-        working_pi_list = current_pi_list.clone
-
-        working_pi_list.delete_at(i)
-
-        if is_PI_Essential( current_pi_list[i], working_pi_list)
-          @essential_pi_list.push( current_pi_list[i])
-        else
-          @non_essential_pi_list.push( current_pi_list[i])
-        end
+      if is_PI_Essential( current_pi_list[i], working_pi_list)
+        @essential_pi_list.push( current_pi_list[i])
+      else
+        @non_essential_pi_list.push( current_pi_list[i])
       end
+    end
 
     categorized_pi_list.push(@essential_pi_list)
     categorized_pi_list.push(@non_essential_pi_list)
-
-    return categorized_pi_list
+    categorized_pi_list
   end
   
   def does_pi_list_fully_cover_function(minterms, current_cover)
@@ -192,8 +185,8 @@ class Algo
 
   def remove_duplicates(cover_list)
     # cover_list = [['0x000', '11010', '00001'], ['101x1', '1x111', 'x0100'], ['11x00', '01010', '00101'], ['11010', '0x000', '00001'], ['00001', '11010', '0x000']] # will get this from Shah's algorithm
-    puts "array of covers (before removing duplicate covers): #{cover_list.inspect}"
-    puts "size of colver_list (before removing duplicates): #{cover_list.length}"
+    # puts "array of covers (before removing duplicate covers): #{cover_list.inspect}"
+    # puts "size of colver_list (before removing duplicates): #{cover_list.length}"
     new_covers = []
     cover_list.each { |cover| new_covers << cover.sort }
     new_covers = new_covers.uniq # removing duplicate covers
@@ -204,21 +197,22 @@ class Algo
 
   def find_minimum_cost_cover(cover_list, file_name)
     starter_kit = StarterKit.new(file_name)
-    puts 'Finding Minimum Cost Cover . . .'
+    puts "\nFinding Minimum Cost Cover . . . "
     new_covers = remove_duplicates(cover_list)
     # Finding covers costs and minimum cost cover
     cover_value_hash = Hash.new{|h, k| h[k] = []}
     new_covers.each do |cover|
       cover_cost = starter_kit.function_cost(cover)
-      puts "cost of cover #{cover}: #{cover_cost}"
+      puts "cost of cover #{cover}: #{cover_cost}".colorize(:light_blue)
       cover_value_hash[cover_cost] << cover
     end
     puts
     # puts "cover_value_hash: #{cover_value_hash.inspect}"
     minimum_cost_cover =  cover_value_hash.sort_by {|key, value| key}
-    puts "minimum_cost_cover: #{minimum_cost_cover[0][1]}"
     puts "minimum_cost_cover length: #{minimum_cost_cover[0][1].length}"
-    puts "cost of minimum_cost_cover: #{minimum_cost_cover[0][0]}"
+    puts "minimum_cost_cover: #{minimum_cost_cover[0][1]}".colorize(:light_blue)
+    puts "cost of minimum_cost_cover: #{minimum_cost_cover[0][0]}".blue.blink
+    puts
     minimum_cost_cover
   end
 end

--- a/Assignment_1_Solution/main.rb
+++ b/Assignment_1_Solution/main.rb
@@ -27,19 +27,15 @@ pi_list = pi.generate_final_prime_implicants(starter_kit.on_set, starter_kit.dc_
 # pi_list = pi.generate_final_prime_implicants(['000x', 'x111'], ['1x0x']) #dc set should be regarded properly
 # puts "final_pi_list: #{pi_list.inspect}"
 
-puts "Initial Cover :"
-puts "#{initial_cover.inspect}"
-puts "Prime Implicant List:"
-puts "#{pi_list.inspect}"
+puts "Initial Cover: #{initial_cover.inspect}".colorize(:green)
+puts "Prime Implicants: #{pi_list.inspect}".colorize(:blue)
 
 categorized_pi_list =  algo.calculate_essential_pi_list(pi_list)
 essential_pi_list = categorized_pi_list[0]
 non_essential_pi_list = categorized_pi_list[1]
 
-puts "This is the essential PI list:"
-puts "#{categorized_pi_list[0].inspect}"
-puts "This is the non-essential PI list:"
-puts "#{categorized_pi_list[1].inspect}"
+puts "essential_pi_list: #{essential_pi_list}".colorize(:blue)
+puts "non-essential_pi_list: #{non_essential_pi_list}".colorize(:blue)
 
 puts "checking if the essential prime implicants fully cover the function"
 minterm_coverage_list = algo.get_minterm_function_coverage(initial_cover, essential_pi_list)
@@ -47,10 +43,8 @@ minterm_coverage_list = algo.get_minterm_function_coverage(initial_cover, essent
 minterms_fully_covered = minterm_coverage_list[0]
 minterms_not_fully_covered = minterm_coverage_list[1]
 
-puts "minterms fully covered:"
-puts "#{minterms_fully_covered.inspect}"
-puts "minterms not fully covered:"
-puts "#{minterms_not_fully_covered.inspect}"
+puts "minterms fully covered: #{minterms_fully_covered.inspect}".colorize(:green)
+puts "minterms not fully covered: #{minterms_not_fully_covered.inspect}".colorize(:green)
 
 if (minterms_not_fully_covered.length == 0)  #all the minterms in the initial cover are covered by the essential PIs
   puts "Essential PIs fully cover the function"
@@ -68,7 +62,4 @@ puts "This is the cover list:"
 end
 
 minimum_cost_cover = algo.find_minimum_cost_cover(cover_list, file_name)
-
-puts "essential_pi_list: #{essential_pi_list}"
-puts "non-essential_pi_list: #{non_essential_pi_list}"
 # algo.generate_pi_combinations(essential_pi_list, non_essential_pi_list).inspect

--- a/Assignment_1_Solution/main.rb
+++ b/Assignment_1_Solution/main.rb
@@ -20,6 +20,12 @@ pi = PrimeImplicant.new
 # initial_cover = ['0x0', '011', '010', 'x11', '1x1']
 # initial_cover = cubes
 # initial_cover = starter_kit.on_set
+
+#debugging....incorporate dc set while finding essential PIs
+
+# starter_kit.on_set = ['000x', 'x111']
+# starter_kit.dc_set = ['1x0x']
+
 initial_cover = starter_kit.on_set
 # pi_list = pi.generate_prime_implicants(initial_cover) #dc set should be regarded properly
 pi_list = pi.generate_final_prime_implicants(starter_kit.on_set, starter_kit.dc_set) #dc set should be regarded properly
@@ -30,7 +36,7 @@ pi_list = pi.generate_final_prime_implicants(starter_kit.on_set, starter_kit.dc_
 puts "Initial Cover: #{initial_cover.inspect}".colorize(:green)
 puts "Prime Implicants: #{pi_list.inspect}".colorize(:blue)
 
-categorized_pi_list =  algo.calculate_essential_pi_list(pi_list)
+categorized_pi_list =  algo.calculate_essential_pi_list(pi_list, starter_kit.dc_set)
 essential_pi_list = categorized_pi_list[0]
 non_essential_pi_list = categorized_pi_list[1]
 


### PR DESCRIPTION
@sninad I have modified the code to calculate the combinations of non-essential PIs only and then adding
essential PIs to those combinations. Small changes. Please look at the code. 

This will speed up the process significantly. As we will process only 16,384 items instead of 1,30,071 items for node 3. I ran it and it took 12 seconds for node 3.

Only problem I see is, its not returning the correct values for node 2, 4 and 3. But the problem is very subtle. 
If you remember, We were getting 1 extra PIs when comparing with Ishtiaque for node 2 and node 4, this is the same issue which I believe (and HOPE) that if you do that single remaining thing (as we discussed), will be fixed. Lets hope for the best.

You can pull this branch using the following command:

`git fetch origin test:test`

and then work on this. You just have to make that small change that you told me. I have done the other part (calculating combinations for non-ess PIs only). Let me know the updates.

More info: (you can also see it by running main.rb file):

For node 2 and node 4 we are getting this:

`minimum_cost_cover: [["0x1x", "x00x", "x0x0", "x111"]]`
`cost of minimum_cost_cover: 18`

which means, we are getting 1 extra PI here which we should not get. And the cost should be 14.

Same problem for node 3 as well, now we get cost 42 instead of 37. So, we are very very close. But this process increased the speed of the program significantly. Now, I just hope, this small issue will be resolved if you do your small remaining thing.

Update:

I just added one more small thing to it: https://github.com/rakibulislam/ECE_1733/commit/7e427af89d81be5d52d1d5c836df4069dfd9353e

Just adding all possible combinations of Ess. PIs to the list instead of just adding the Ess. PI and now we get the correct costs and values for node 2 and node 4 as well.

SO, 1,2,4,5 is working nicely.

But, still the cost for node 3 is showing as 42 which I believe will be fixed with your final change. Looking forward to that eagerly.
